### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/ISBFirmProject/a40dfc55-846c-42e7-b37a-1d496f5bd857/3e417f39-d7e0-4083-9c19-86f632321c55/_apis/work/boardbadge/84ae0ea7-6df6-4740-9d44-672e2c236701)](https://dev.azure.com/ISBFirmProject/a40dfc55-846c-42e7-b37a-1d496f5bd857/_boards/board/t/3e417f39-d7e0-4083-9c19-86f632321c55/Microsoft.RequirementCategory)
 # gitBoards


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#323](https://dev.azure.com/ISBFirmProject/a40dfc55-846c-42e7-b37a-1d496f5bd857/_workitems/edit/323). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.